### PR TITLE
Add support for btrfs filesystems

### DIFF
--- a/sources/modules/base/fs.cil
+++ b/sources/modules/base/fs.cil
@@ -146,6 +146,7 @@
 (fsuse trans "tmpfs" tmpfs)
 (fsuse xattr "ext4" fs)
 (fsuse xattr "xfs" fs)
+(fsuse xattr "btrfs" fs)
 
 (genfscon "afs" "/" nfs)
 (genfscon "aio" "/" aio)


### PR DESCRIPTION
Adds an fsuse expression to label btrfs as supporting SELinux.

Had some troubles on a F24 vm with a BTRFS filesystem, output from what I was seeing:
```
/sbin/restorecon set context /usr/bin->sys.id:sys.role:cmd.cmd_file:s0 failed:'Operation not supported'
/sbin/restorecon set context /usr/sbin->sys.id:sys.role:cmd.cmd_file:s0 failed:'Operation not supported'
/sbin/restorecon set context /usr/libexec->sys.id:sys.role:cmd.cmd_file:s0 failed:'Operation not supported'
/sbin/restorecon set context /etc->sys.id:sys.role:config.config_file:s0 failed:'Operation not supported'
/sbin/restorecon set context /usr/lib/systemd/system->sys.id:sys.role:sd_unit.unit_file:s0 failed:'Operation not supported'
/sbin/restorecon set context /var/lib->sys.id:sys.role:var_lib.var_lib_file:s0 failed:'Operation not supported'
/sbin/restorecon set context /var/cache->sys.id:sys.role:var_cache.var_cache_file:s0 failed:'Operation not supported'
```